### PR TITLE
Add HF mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,14 @@ To load directly from Hugging Face, you can do the following:
 
   ```python
   from models.audiosep import AudioSep
+  from utils import get_ss_model
   import torch
 
   device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
-  model = AudioSep.from_pretrained("")
+  ss_model = get_ss_model('config/audiosep_base.yaml')
+
+  model = AudioSep.from_pretrained("nielsr/audiosep-demo", ss_model=ss_model)
 
   audio_file = 'path_to_audio_file'
   text = 'textual_description'

--- a/README.md
+++ b/README.md
@@ -55,6 +55,24 @@ Download [model weights](https://huggingface.co/spaces/Audio-AGI/AudioSep/tree/m
 
 <hr>
 
+To load directly from Hugging Face, you can do the following:
+
+  ```python
+  from models.audiosep import AudioSep
+  from utils import load_separation_model
+
+  device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+  model = AudioSep.from_pretrained("")
+
+  audio_file = 'path_to_audio_file'
+  text = 'textual_description'
+  output_file='separated_audio.wav'
+
+  # AudioSep processes the audio at 32 kHz sampling rate  
+  inference(model, audio_file, text, output_file, device)
+  ```
+
 ## Training 
 
 To utilize your audio-text paired dataset:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Download [model weights](https://huggingface.co/spaces/Audio-AGI/AudioSep/tree/m
 
   ```python
   from pipeline import build_audiosep, inference
+  import torch
 
   device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
@@ -59,7 +60,7 @@ To load directly from Hugging Face, you can do the following:
 
   ```python
   from models.audiosep import AudioSep
-  from utils import load_separation_model
+  import torch
 
   device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 

--- a/models/audiosep.py
+++ b/models/audiosep.py
@@ -6,6 +6,8 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.optim.lr_scheduler import LambdaLR
 
+from models.clap_encoder import CLAP_Encoder
+
 from huggingface_hub import PyTorchModelHubMixin
 
 
@@ -14,7 +16,7 @@ class AudioSep(pl.LightningModule, PyTorchModelHubMixin):
         self,
         ss_model: nn.Module = None,
         waveform_mixer = None,
-        query_encoder: nn.Module = None,
+        query_encoder: nn.Module = CLAP_Encoder().eval(),
         loss_function = None,
         optimizer_type: str = None,
         learning_rate: float = None,

--- a/models/audiosep.py
+++ b/models/audiosep.py
@@ -6,18 +6,20 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.optim.lr_scheduler import LambdaLR
 
+from huggingface_hub import PyTorchModelHubMixin
 
-class AudioSep(pl.LightningModule):
+
+class AudioSep(pl.LightningModule, PyTorchModelHubMixin):
     def __init__(
         self,
-        ss_model: nn.Module,
-        waveform_mixer,
-        query_encoder,
-        loss_function,
-        optimizer_type: str,
-        learning_rate: float,
-        lr_lambda_func,
-        use_text_ratio=1.0,
+        ss_model: nn.Module = None,
+        waveform_mixer = None,
+        query_encoder: nn.Module = None,
+        loss_function = None,
+        optimizer_type: str = None,
+        learning_rate: float = None,
+        lr_lambda_func = None,
+        use_text_ratio: float =1.0,
     ):
         r"""Pytorch Lightning wrapper of PyTorch model, including forward,
         optimization of model, etc.

--- a/models/clap_encoder.py
+++ b/models/clap_encoder.py
@@ -5,7 +5,6 @@ import torchaudio
 from models.CLAP.open_clip import create_model
 from models.CLAP.training.data import get_audio_features
 from transformers import RobertaTokenizer
-from utils import ignore_warnings; ignore_warnings()
 
 
 class CLAP_Encoder(nn.Module):

--- a/utils.py
+++ b/utils.py
@@ -323,6 +323,35 @@ def loudness(data, input_loudness, target_loudness):
     return output
 
 
+def get_ss_model(configs: Dict) -> nn.Module:
+    r"""Load trained universal source separation model.
+
+    Args:
+        configs (Dict)
+        checkpoint_path (str): path of the checkpoint to load
+        device (str): e.g., "cpu" | "cuda"
+
+    Returns:
+        pl_model: pl.LightningModule
+    """
+
+    ss_model_type = configs["model"]["model_type"]
+    input_channels = configs["model"]["input_channels"]
+    output_channels = configs["model"]["output_channels"]
+    condition_size = configs["model"]["condition_size"]
+    
+    # Initialize separation model
+    SsModel = get_model_class(model_type=ss_model_type)
+
+    ss_model = SsModel(
+        input_channels=input_channels,
+        output_channels=output_channels,
+        condition_size=condition_size,
+    )
+
+    return ss_model
+
+
 def load_ss_model(
     configs: Dict,
     checkpoint_path: str,

--- a/utils.py
+++ b/utils.py
@@ -323,7 +323,7 @@ def loudness(data, input_loudness, target_loudness):
     return output
 
 
-def get_ss_model(configs: Dict) -> nn.Module:
+def get_ss_model(config_yaml) -> nn.Module:
     r"""Load trained universal source separation model.
 
     Args:
@@ -334,6 +334,7 @@ def get_ss_model(configs: Dict) -> nn.Module:
     Returns:
         pl_model: pl.LightningModule
     """
+    configs = parse_yaml(config_yaml)
 
     ss_model_type = configs["model"]["model_type"]
     input_channels = configs["model"]["input_channels"]


### PR DESCRIPTION
This PR enables to directly load AudioSep models from the 🤗 hub, rather than people having to download them first manually (by simply making the model inherit from the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class). The additional benefit is that you'll see actual download numbers (similar to HF models) on the hub, you can add a model card to your model, etc. I've pushed a model here: https://huggingface.co/nielsr/audiosep-demo

Here's how to use it, using the familiar `from_pretrained` method:

```
from models.audiosep import AudioSep
from utils import get_ss_model

ss_model = get_ss_model('config/audiosep_base.yaml')
model = AudioSep.from_pretrained("nielsr/audiosep-demo", ss_model=ss_model)
```
Inference can then be done in the same way:
```
audio_file = 'exp31_water drops_mixture.wav'
text = 'water drops'
output_file='separated_audio.wav'

# AudioSep processes the audio at 32 kHz sampling rate
inference(model, audio_file, text, output_file, device)
```
One also directly inherits the from_pretrained and push_to_hub methods:
```
# save model locally
model.save_pretrained("my-awesome-audiosep-model")
model.push_to_hub("nielsr/my-audiosep-model")
```

It could be improved even more by defining attributes (similar to models in HF Transformers), such as input_channels, output_channels as part of the model's init such that those can be saved in a config.json on the hub, such that one can skip having to load the `ss_model`, allowing to just do:

```
from models.audiosep import AudioSep

model = AudioSep.from_pretrained("nielsr/audiosep-demo")
```
However the latter would require a breaking change, so if you don't want breaking changes you could just use solution 1. Let me know whether you are interested.

Kind regards,

Niels
ML @ HF