### PR TITLE
fix typos in python function definition helper text

### DIFF
--- a/models/CLAP/open_clip/feature_fusion.py
+++ b/models/CLAP/open_clip/feature_fusion.py
@@ -1,5 +1,5 @@
 """
-Feature Fusion for Varible-Length Data Processing
+Feature Fusion for Variable-Length Data Processing
 AFF/iAFF is referred and modified from https://github.com/YimianDai/open-aff/blob/master/aff_pytorch/aff_net/fusion.py
 According to the paper: Yimian Dai et al, Attentional Feature Fusion, IEEE Winter Conference on Applications of Computer Vision, WACV 2021
 """

--- a/models/CLAP/open_clip/htsat.py
+++ b/models/CLAP/open_clip/htsat.py
@@ -469,7 +469,7 @@ class SwinTransformerBlock(nn.Module):
     r"""Swin Transformer Block.
     Args:
         dim (int): Number of input channels.
-        input_resolution (tuple[int]): Input resulotion.
+        input_resolution (tuple[int]): Input resolution.
         num_heads (int): Number of attention heads.
         window_size (int): Window size.
         shift_size (int): Shift size for SW-MSA.

--- a/models/CLAP/open_clip/linear_probe.py
+++ b/models/CLAP/open_clip/linear_probe.py
@@ -10,7 +10,7 @@ class LinearProbe(nn.Module):
         Args:
             model: nn.Module
             mlp: bool, if True, then use the MLP layer as the linear probe module
-            freeze: bool, if Ture, then freeze all the CLAP model's layers when training the linear probe
+            freeze: bool, if True, then freeze all the CLAP model's layers when training the linear probe
             in_ch: int, the output channel from CLAP model
             out_ch: int, the output channel from linear probe (class_num)
             act: torch.nn.functional, the activation function before the loss function

--- a/models/CLAP/open_clip/tokenizer.py
+++ b/models/CLAP/open_clip/tokenizer.py
@@ -27,7 +27,7 @@ def bytes_to_unicode():
     The reversible bpe codes work on unicode strings.
     This means you need a large # of unicode characters in your vocab if you want to avoid UNKs.
     When you're at something like a 10B token dataset you end up needing around 5K for decent coverage.
-    This is a signficant percentage of your normal, say, 32K bpe vocab.
+    This is a significant percentage of your normal, say, 32K bpe vocab.
     To avoid that, we want lookup tables between utf-8 bytes and unicode strings.
     And avoids mapping to whitespace/control characters the bpe code barfs on.
     """


### PR DESCRIPTION
This pull request fixes typos in function definition helper text. I kindly request the repository maintainers to review and merge it. Thanks! :heart: 